### PR TITLE
added missing configuration for vaadin-maven-plugin in demo

### DIFF
--- a/HybridMenu-demo/pom.xml
+++ b/HybridMenu-demo/pom.xml
@@ -108,6 +108,9 @@
 				<groupId>com.vaadin</groupId>
 				<artifactId>vaadin-maven-plugin</artifactId>
 				<version>${vaadin.plugin.version}</version>
+				<configuration>
+					<widgetsetMode>fetch</widgetsetMode>
+				</configuration>
 				<executions>
 					<!-- You are free to mark this as permanently ignored in Eclipse -->
 					<execution>


### PR DESCRIPTION
Added the missing configuration to the POM
````
<plugin>
  <groupId>com.vaadin</groupId>
  <artifactId>vaadin-maven-plugin</artifactId>
  <version>${vaadin.plugin.version}</version>
  <configuration>
    <widgetsetMode>fetch</widgetsetMode>
  </configuration>
  ...
</plugin>
````